### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/ssi.py
+++ b/ssi.py
@@ -12,9 +12,9 @@ def InlineIncludes(path, web_path):
     if  len(os.path.dirname(web_path)) >2:
        file_to_read = os.path.join(os.path.dirname(web_path),file_to_read)[1:]
     if os.path.exists(file_to_read):
-        return file(file_to_read).read()
+        return open(file_to_read).read()
     
-  content = file(path).read()
+  content = open(path).read()
   content = re.sub(r'<!-- *#include *(virtual|file)=[\'"]([^\'"]+)[\'"] *-->',
       get_include_file_content,
       content)

--- a/ssi_server.py
+++ b/ssi_server.py
@@ -14,8 +14,14 @@ Run ./ssi_server.py in this directory and visit localhost:8000 for an exmaple.
 
 import os
 import ssi
-from SimpleHTTPServer import SimpleHTTPRequestHandler
-import SimpleHTTPServer
+try:
+    # This works for Python 2
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+    import SimpleHTTPServer
+except ImportError:
+    # This works for Python 3
+    from http.server import SimpleHTTPRequestHandler
+    import http.server as SimpleHTTPServer
 import tempfile
 
 
@@ -61,7 +67,10 @@ class SSIRequestHandler(SimpleHTTPRequestHandler):
     if ext == ".shtml":
         ext = ".html"
     fd, path = tempfile.mkstemp(suffix=ext)
-    os.write(fd, content)
+    try:
+        os.write(fd, content)  # This works for Python 2
+    except TypeError:
+        os.write(fd, bytes(content, 'UTF-8'))  # This works for Python 3
     os.close(fd)
 
     self.temp_files.append(path)


### PR DESCRIPTION
I love this sweet little tool for when I have to edit an SSI-powered website. Unfortunately, `ssi-server` does not appear to work on Python 3.  The attached PR shows a solution.  (Which is total hack; I have only just switched to Python 3 and have no proper experience porting code.)

(PS: Please add a license, I can't tell if it is ok to edit your code otherwise.)